### PR TITLE
Import working again

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Use at your own risk! Please test on a dummy Discourse install first.
 
 * Import likes
 * Don't send notification mails
+* FB <-> Discourse synchronisation (post written on FB appears on Discourse and vice versa)
+* FB notifications after posting on Discourse
 
 # Changelog
 v. 1.7 (fork from author)

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Use at your own risk! Please test on a dummy Discourse install first.
 
 # Changelog
 v. 1.7 (fork from author)
- New:
+
+New:
  - import only posts and messages not imported previously
- Fixed:
+
+Fixed:
  - FB usernames with national chars import
  - short post/comments import
  - FB users/posts/comments fetching

--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ Use at your own risk! Please test on a dummy Discourse install first.
 
 # Todo
 
-* Update code to work with latest Discourse methods
 * Import likes
-* Import new posts/comments after last import
 * Don't send notification mails
+
+# Changelog
+v. 1.7 (fork from author)
+ New:
+ - import only posts and messages not imported previously
+ Fixed:
+ - FB usernames with national chars import
+ - short post/comments import
+ - FB users/posts/comments fetching
+

--- a/config/import_facebook.yml
+++ b/config/import_facebook.yml
@@ -4,13 +4,13 @@
 
 # Get this token here: https://developers.facebook.com/tools/explorer
 # Select user_groups and read_stream as permission
-facebook_token: CAACEdEose0cBAPhoRRNr2n2ZCppT1HJPlB4HiTQaAdyaTMLF47pEmlFWdXIrUGgGkLlEukkmGPaDMLWAm8N4krS00IJ6e9XtaPdwZBLV54ZC1ZAIbaX6ZBcM2A37HbbX59xoOpECajyNPA1BGwMUn7dlO67ReygE0RAZBUCHQwso388X2UrZCkesDDej9gYC58WTJuopjOzj3lmhEOZBtLuMeLcoJ6fcVRsZD
+facebook_token: FACEBOOK_TOKEN
 
 # The group ID you want to export posts from. Need to be a member of this group.
-facebook_group_id: 1443681709189839
+facebook_group_id: FACEBOOK_GROUP_ID
 
 # The category for the topics, will be created if needed
-discourse_category_name: Osiedle
+discourse_category_name: Category
 
 # User with admin privileges to create users and category
 discourse_admin: admin

--- a/config/import_facebook.yml
+++ b/config/import_facebook.yml
@@ -4,16 +4,16 @@
 
 # Get this token here: https://developers.facebook.com/tools/explorer
 # Select user_groups and read_stream as permission
-facebook_token: FACEBOOK_TOKEN
+facebook_token: CAACEdEose0cBAPhoRRNr2n2ZCppT1HJPlB4HiTQaAdyaTMLF47pEmlFWdXIrUGgGkLlEukkmGPaDMLWAm8N4krS00IJ6e9XtaPdwZBLV54ZC1ZAIbaX6ZBcM2A37HbbX59xoOpECajyNPA1BGwMUn7dlO67ReygE0RAZBUCHQwso388X2UrZCkesDDej9gYC58WTJuopjOzj3lmhEOZBtLuMeLcoJ6fcVRsZD
 
-# The group you want to export posts from. Need to be a member of this group.
-facebook_group_name: Some Facebook Group Name
+# The group ID you want to export posts from. Need to be a member of this group.
+facebook_group_id: 1443681709189839
 
 # The category for the topics, will be created if needed
-discourse_category_name: Some Category Name
+discourse_category_name: Osiedle
 
 # User with admin privileges to create users and category
-discourse_admin: Admin Username
+discourse_admin: admin
 
 # If true then nothing will be written to the Discourse database
 test_mode: false

--- a/lib/tasks/import_facebook.rake
+++ b/lib/tasks/import_facebook.rake
@@ -51,7 +51,6 @@
 ############################################################
  
 require 'koala'
-require 'byebug'
 require 'stringex'
  
 desc "Import posts and comments from a Facebook group"


### PR DESCRIPTION
# Changelog

v. 1.7 (fork from author)

New:
- import only posts and messages not imported previously

Fixed:
- FB usernames with national chars import
- short post/comments import
- FB users/posts/comments fetching
